### PR TITLE
Fix hover preview width and add backdrop test

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SanchezPortfolio</title>
+  <title>Sanchez Portfolio</title>
 
   <!-- Tailwind CSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -269,7 +269,7 @@ bd.addEventListener('touchmove', (e)=> e.preventDefault(), { passive: false });
     const remove = (cls)=> document.body.classList.remove(cls);
 
      /* removed: duplicate mobile center-pick for shelf-active.
-       The IntersectionObserver at 0.7 handles this. */
+       The IntersectionObserver (≥50% visible) handles this. */
 
     // Preview control state
 let hoverTimer = null;
@@ -361,7 +361,7 @@ suppressTapUntil = Date.now() + 200;
       currentPreviewCard = cardEl;
 
       const rect = cardEl.getBoundingClientRect();
-      const w = PREVIEW_MIN_W; // fixed
+      const w = Math.min(PREVIEW_MAX_W, innerWidth - 32);
       const estH = w * 9/16 + PREVIEW_BODY_EXTRA;
       const left = clamp(rect.left, 16, innerWidth - w - 16);
       const top  = clamp(rect.top + rect.height/2 - estH/2, 16, innerHeight - estH - 16);
@@ -790,6 +790,10 @@ card.addEventListener('touchend', (e)=>{
   console.assert(!!window.__hoverPreview, 'hover preview element exists');
   console.assert(typeof window.setThumb==='function','setThumb exposed');
   console.assert(getComputedStyle(document.querySelector('.hover-preview')).pointerEvents==='none','preview overlay pointer-events none');
+  console.assert(() => {
+    const backdrop = document.querySelector('.hp-backdrop');
+    return backdrop && getComputedStyle(backdrop).display === 'none';
+  }(), 'hover preview backdrop hidden by default');
   console.assert(document.querySelectorAll('.content-card').length>=30,'cards rendered');
   (function(){
     const hp = window.__hoverPreview;


### PR DESCRIPTION
## Summary
- add the missing space in the document title
- clamp the hover preview width on narrow viewports and refresh the IntersectionObserver guidance comment
- assert that the hover preview backdrop starts hidden during smoke tests

## Testing
- not run (not requested)

## Before
```html
      const w = PREVIEW_MIN_W; // fixed
      const estH = w * 9/16 + PREVIEW_BODY_EXTRA;
```

## After
```html
      const w = Math.min(PREVIEW_MAX_W, innerWidth - 32);
      const estH = w * 9/16 + PREVIEW_BODY_EXTRA;
```


------
https://chatgpt.com/codex/tasks/task_e_68def51cfdd88324bdfbd13529467232