### PR TITLE
Adjust mobile content shelf spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ body.no-scroll main{overflow:hidden!important}
   main>section,.content-shelf{scroll-snap-align:start;scroll-snap-stop:normal}
 
   /* 4) Shelves are tighter; headings subtle */
-  .content-shelf{min-height:56svh;padding-block:2svh;padding-inline:0;display:flex;flex-direction:column;justify-content:center;gap:.5rem}
+  .content-shelf{padding-block:2svh;padding-inline:0;display:flex;flex-direction:column;gap:.5rem}
   .content-shelf>h3{margin:0 0 .5rem 0!important;color:#e5e7eb;font-weight:700} /* more space under title */
   .content-shelf>h3::after{content:"";display:block;height:1px;background:linear-gradient(to right,rgba(255,255,255,.18),rgba(255,255,255,.04));margin-top:.25rem}
   .content-shelf.shelf-active>h3{color:#fff}


### PR DESCRIPTION
## Summary
- remove the forced minimum height on mobile content shelves so they collapse to content
- drop the centering justification so shelf headings align with the top padding while retaining existing gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0559858883248a95f0efc058ae62