### PR TITLE
Add hero gradient fade overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 .video-background-container iframe{position:absolute;top:50%;left:50%;min-width:100vw;min-height:100vh;transform:translate(-50%,-50%);pointer-events:none}
 @media (min-aspect-ratio:16/9){.video-background-container iframe{height:56.25vw;min-height:100vh}}
 @media (max-aspect-ratio:16/9){.video-background-container iframe{width:177.78vh;min-width:100vw}}
+.hero::after{content:"";position:absolute;left:0;right:0;bottom:0;height:24svh;background:linear-gradient(to top,rgba(0,0,0,.95),rgba(0,0,0,0));pointer-events:none;z-index:5}
 
 /* ---------------- Preview ---------------- */
 .hover-preview{position:fixed;z-index:9999;pointer-events:none;min-width:min(92vw,520px);max-width:min(92vw,520px);border-radius:.75rem;overflow:hidden;box-shadow:0 25px 70px rgba(0,0,0,.6),0 10px 25px rgba(0,0,0,.45);background:#111;opacity:0;transform:translate(0,0) scale(.98);transform-origin:top left;transition:transform .18s cubic-bezier(.2,.8,.2,1),opacity .16s ease}


### PR DESCRIPTION
## Summary
- add a hero ::after gradient overlay so the trailer fades smoothly into black while keeping the existing gradient div under the copy

## Testing
- visual verification on desktop and iPhone 8 viewports

------
https://chatgpt.com/codex/tasks/task_e_68df093882988324b322d115ec167288