### PR TITLE
Stabilize mobile hero anchor spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,10 @@ body.no-scroll main{overflow:hidden!important}
     --m-hero-vid-w:192vw;          /* punch-in width (~50% total) */
     --m-hero-vid-h:108vw;          /* 16:9 of 192vw */
     --m-hero-gap:24px;             /* base vertical spacing unit */
-    --m-hero-synopsis-line:1.5rem; /* synopsis line-height (≈24px) */
-    --m-synopsis-firstline-offset:calc(68px + (var(--m-hero-synopsis-line) * 3)); /* chip stack + three synopsis lines */
-    --m-gap-ctas-to-row:calc(var(--m-hero-gap) * 1.5);      /* tighter gap above first shelf title */
+    --m-hero-line:1.5rem;          /* synopsis line-height (≈24px) */
+    --m-hero-tagline-height:44px;  /* chip + tagline block height */
+    --m-synopsis-firstline-offset:calc(var(--m-hero-tagline-height) + var(--m-hero-gap) + (var(--m-hero-line) * 3));
+    --m-gap-ctas-to-row:calc(var(--m-hero-gap) * 1.5);
   }
 
   /* mobile-hero-iframe */
@@ -85,12 +86,24 @@ body.no-scroll main{overflow:hidden!important}
     position:absolute; left:0; right:0;
     top:calc(var(--m-hero-vid-h) - var(--m-synopsis-firstline-offset));
   }
+  .hero-content>p:nth-of-type(1){
+    margin-bottom:var(--m-hero-gap);
+    line-height:var(--m-hero-line);
+  }
+  .hero-content>p:nth-of-type(2){
+    margin-bottom:var(--m-hero-gap);
+    line-height:var(--m-hero-line);
+    display:-webkit-box;
+    -webkit-line-clamp:4;
+    -webkit-box-orient:vertical;
+    overflow:hidden;
+  }
   .hero.dimmed{transform:translateY(-8px) scale(.94)}
   .content-card:hover{transform:none!important;box-shadow:none!important;z-index:auto!important}
 
   .hero-tagline{
     margin-bottom:var(--m-hero-gap);
-    line-height:1.2;
+    line-height:var(--m-hero-line);
   }
 
   .hero-synopsis{
@@ -98,8 +111,8 @@ body.no-scroll main{overflow:hidden!important}
     display:-webkit-box;
     -webkit-box-orient:vertical;
     -webkit-line-clamp:4;
-    line-height:var(--m-hero-synopsis-line);
-    max-height:calc(var(--m-hero-synopsis-line) * 4);
+    line-height:var(--m-hero-line);
+    max-height:calc(var(--m-hero-line) * 4);
     overflow:hidden;
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated mobile variable for the hero tagline block height
- derive the synopsis anchor offset from the tagline height so the content sits correctly after the line-height changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df161109108324b1e139e250557321