### PR TITLE
Adjust content shelf spacing for tighter layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 .title-chip-text{font-weight:800;letter-spacing:.08em;color:#e50914;font-size:1.125rem}
 @media (min-width:768px){.title-chip-text{font-size:1.5rem}}
 @media (max-width:768px){.title-chip{padding:.4rem .75rem}.title-chip-text{font-size:1rem;letter-spacing:.09em}}
-.content-shelf{padding-block:1.25rem;margin:0;content-visibility:auto;contain-intrinsic-size:600px}
+.content-shelf{padding-block:.75rem;margin:0;content-visibility:auto;contain-intrinsic-size:600px}
 
 /* ---------------- Hero video ---------------- */
 .video-background-container{position:absolute;inset:0;overflow:hidden;z-index:0}
@@ -61,7 +61,6 @@ body.no-scroll main{overflow:hidden!important}
     --m-hero-tagline-line:1.2;     /* compact tagline leading */
     --m-hero-tagline-height:44px;  /* chip + tagline block height */
     --m-synopsis-firstline-offset:calc(var(--m-hero-tagline-height) + var(--m-hero-gap) + (var(--m-hero-line) * 3));
-    --m-gap-ctas-to-row:calc(var(--m-hero-gap) * 1.5);
   }
 
   /* mobile-hero-iframe */
@@ -141,17 +140,17 @@ body.no-scroll main{overflow:hidden!important}
   main>section,.content-shelf{scroll-snap-align:start;scroll-snap-stop:normal}
 
   /* 4) Shelves are tighter; headings subtle */
-  .content-shelf{padding-block:1rem;padding-inline:0;display:flex;flex-direction:column;gap:.5rem}
+  .content-shelf{padding-block:.75rem;padding-inline:0;display:flex;flex-direction:column;gap:.5rem}
   .content-shelf>h3{margin:0 0 .5rem 0!important;color:#e5e7eb;font-weight:700} /* more space under title */
   .content-shelf>h3::after{content:"";display:block;height:1px;background:linear-gradient(to right,rgba(255,255,255,.18),rgba(255,255,255,.04));margin-top:.25rem}
   .content-shelf.shelf-active>h3{color:#fff}
 
   /* mobile-rowA-peek */
   /* 5) Minimize peek on short phones and add breathing room */
-  .content-shelf:first-of-type{margin-top:0;padding-top:1.5rem}
+  .content-shelf:first-of-type{margin-top:0;padding-top:1.25rem}
   .content-shelf:first-of-type>h3{
     opacity:1;pointer-events:auto;
-    margin-top:var(--m-gap-ctas-to-row) !important;
+    margin-top:.75rem !important;
   }
   .content-shelf.shelf-active:first-of-type>h3{opacity:1;pointer-events:auto}
 }
@@ -209,7 +208,7 @@ body.no-scroll main{overflow:hidden!important}
     </section>
 
     <!-- Content Shelves Section -->
-    <section class="relative z-10 space-y-2 px-0 md:px-8 pb-12">
+    <section class="relative z-10 flex flex-col gap-3 px-0 md:px-8 pb-12">
       <div class="content-shelf px-6 md:px-4">
         <h3 class="text-xl md:text-2xl font-bold mb-2 ml-2">Popular on Stream (Scrolls Left)</h3>
         <div class="shelf-row relative overflow-x-auto overflow-y-visible no-scrollbar py-2 group/shelf"></div>


### PR DESCRIPTION
## Summary
- reduce the base and mobile padding on content shelves to match the tighter reference spacing
- switch the shelves section wrapper to an explicit flex gap and align the first shelf spacing with the new padding
- replace the hero-to-row handoff margin variable with a smaller fixed value for a smoother transition

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df25c0ca608324b49022601b58767f