### PR TITLE
Refine mobile hero flow and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,8 @@ body.no-scroll main{overflow:hidden!important}
     transform:none;
     width:100vw;
     max-width:100%;
-    height:56.25vw; /* maintain 16:9 while matching viewport width */
+    aspect-ratio:16/9;
+    height:auto;
     min-width:0;
     min-height:0;
     object-fit:cover;
@@ -86,20 +87,19 @@ body.no-scroll main{overflow:hidden!important}
   .hero{
     min-height:64svh;         /* ensures room for overlayed content */
     background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
-    padding-top:calc(env(safe-area-inset-top,0px) + 68px);
-    padding-bottom:calc(var(--m-hero-gap) * 1.5);
+    padding-top:calc(env(safe-area-inset-top,0px) + 56px);
+    padding-bottom:calc(var(--m-hero-gap) * 2);
     transition:transform 220ms cubic-bezier(.2,.8,.2,1);
     display:flex;
     flex-direction:column;
-    justify-content:flex-end;
+    justify-content:flex-start;
     align-items:stretch;
-    gap:var(--m-hero-gap);
+    gap:calc(var(--m-hero-gap) * 1.1);
   }
 
   /* mobile-hero-content-anchor */
   /* Flex stack the content below the video */
   .hero .hero-content{
-    position:relative;
     width:100%;
     padding-inline:1.5rem;
     display:flex;
@@ -128,7 +128,7 @@ body.no-scroll main{overflow:hidden!important}
   }
 
   /* Put buttons on one line, make them smaller */
-  .hero .grid{gap:.75rem;grid-template-columns:repeat(2,minmax(0,1fr));margin-top:0;width:100%}
+  .hero .grid{gap:.75rem;grid-template-columns:repeat(2,minmax(0,1fr));margin-top:calc(var(--m-hero-gap) * .5);width:100%}
   .hero .grid button{padding:.45rem .7rem;min-height:38px;border-radius:9999px}
   .hero .grid button svg{width:18px;height:18px}
   .hero .grid button .text-lg{font-size:.9rem;line-height:1.2rem}


### PR DESCRIPTION
## Summary
- stack the hero video and content vertically on mobile so copy and CTAs follow the iframe
- simplify the mobile iframe sizing with a 16:9 aspect ratio and update hero spacing for better breathing room

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfc2dac9b8832485745ddeac67c6a0