### PR TITLE
Update nav styling and adjust hero spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ body.no-scroll main{overflow:hidden!important}
   .hero{
     min-height:64svh;         /* ensures room for overlayed content */
     background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
-    padding-top:calc(env(safe-area-inset-top,0px) + 56px);
+    padding-top:calc(env(safe-area-inset-top,0px) + 24px);
     padding-bottom:calc(var(--m-hero-gap) * 2);
     transition:transform 220ms cubic-bezier(.2,.8,.2,1);
     display:flex;
@@ -160,7 +160,7 @@ body.no-scroll main{overflow:hidden!important}
   .shelf-row{padding-block:.5rem;padding-inline:0}
 
   /* 3) Section snap for “vertical cards sliding” feel */
-  main{scroll-snap-type:y mandatory;overscroll-behavior-y:contain;scroll-padding-top:calc(env(safe-area-inset-top,0px) + 56px);-webkit-overflow-scrolling:touch;scroll-behavior:smooth}
+  main{scroll-snap-type:y mandatory;overscroll-behavior-y:contain;scroll-padding-top:calc(env(safe-area-inset-top,0px) + 80px);-webkit-overflow-scrolling:touch;scroll-behavior:smooth}
   main>section,.content-shelf{scroll-snap-align:start;scroll-snap-stop:normal}
 
   /* 4) Shelves are tighter; headings subtle */
@@ -186,11 +186,11 @@ body.no-scroll main{overflow:hidden!important}
 </head>
 <body class="overflow-x-hidden overflow-y-hidden h-[100svh] md:overflow-y-visible md:h-auto">
   <!-- Fixed Navigation Bar -->
-  <nav class="fixed top-0 left-0 right-0 bg-gradient-to-b from-black/90 to-transparent p-4 z-[100] flex items-center justify-between">   <div class="flex items-center space-x-8">     <a href="/" class="text-xl sm:text-2xl font-extrabold text-red-600 tracking-wide sm:tracking-wider whitespace-nowrap" aria-label="SanchezNinjah home">SanchezNinjah</a>     <ul class="hidden md:flex items-center space-x-6 text-sm font-medium text-gray-300">       <li><a href="/" class="text-white font-bold border-b-2 border-red-600 pb-1" aria-current="page">Home</a></li>       <li><a href="/shows" class="hover:text-white">TV Shows</a></li>       <li><a href="/movies" class="hover:text-white">Movies</a></li>       <li><a href="/list" class="hover:text-white">My List</a></li>     </ul>   </div>   <div class="flex items-center space-x-4">     <svg aria-hidden="true" focusable="false" class="w-6 h-6 text-gray-300 hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>     <svg aria-hidden="true" focusable="false" class="w-6 h-6 text-gray-300 hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>   </div> </nav>
-<main class="h-[100svh] overflow-y-auto md:h-auto md:overflow-visible">
+  <nav class="fixed top-0 left-0 right-0 bg-black border-b border-white/10 shadow-lg p-4 z-[100] flex items-center justify-between">   <div class="flex items-center space-x-8">     <a href="/" class="text-xl sm:text-2xl font-extrabold text-red-600 tracking-wide sm:tracking-wider whitespace-nowrap" aria-label="SanchezNinjah home">SanchezNinjah</a>     <ul class="hidden md:flex items-center space-x-6 text-sm font-medium text-gray-300">       <li><a href="/" class="text-white font-bold border-b-2 border-red-600 pb-1" aria-current="page">Home</a></li>       <li><a href="/shows" class="hover:text-white">TV Shows</a></li>       <li><a href="/movies" class="hover:text-white">Movies</a></li>       <li><a href="/list" class="hover:text-white">My List</a></li>     </ul>   </div>   <div class="flex items-center space-x-4">     <svg aria-hidden="true" focusable="false" class="w-6 h-6 text-gray-300 hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>     <svg aria-hidden="true" focusable="false" class="w-6 h-6 text-gray-300 hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>   </div> </nav>
+<main class="h-[100svh] overflow-y-auto md:h-auto md:overflow-visible pt-20 md:pt-24">
   <h1 class="sr-only">SanchezNinjah portfolio</h1>
     <!-- Hero Section -->
-    <section class="hero relative min-h-[70svh] md:min-h-[100svh] flex items-end pb-4 md:pb-32 pt-0 md:pt-24 text-white">
+    <section class="hero relative min-h-[70svh] md:min-h-[100svh] flex items-end pb-4 md:pb-24 pt-4 md:pt-8 text-white">
       <div class="video-background-container">
         <iframe id="heroVideo" src="https://www.youtube-nocookie.com/embed/VBdaOkpLe_o?autoplay=1&mute=1&loop=1&playlist=VBdaOkpLe_o&controls=0&modestbranding=1&enablejsapi=1" title="Background trailer" playsinline referrerpolicy="strict-origin-when-cross-origin" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
       </div>


### PR DESCRIPTION
## Summary
- replace the transparent gradient nav background with a solid black bar, adding a subtle border and shadow for definition
- add top padding to the main content so the hero video sits below the fixed header and trim redundant hero padding
- synchronize mobile hero and scroll padding with the new header spacing for consistent offsets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd4c582c88324b16f0b5ccc84b631