### PR TITLE
Adjust hero video scaling for top-anchored framing

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 
 /* ---------------- Hero video ---------------- */
 .video-background-container{position:absolute;inset:0;overflow:hidden;z-index:0}
-.video-background-container iframe{position:absolute;top:50%;left:50%;min-width:100vw;min-height:100vh;transform:translate(-50%,-50%);pointer-events:none}
+.video-background-container iframe{position:absolute;top:0;left:50%;min-width:100vw;min-height:100vh;transform-origin:top center;transform:translateX(-50%) scale(1.3);pointer-events:none}
 @media (min-aspect-ratio:16/9){.video-background-container iframe{height:56.25vw;min-height:100vh}}
 @media (max-aspect-ratio:16/9){.video-background-container iframe{width:177.78vh;min-width:100vw}}
 .hero::after{content:"";position:absolute;inset-inline:0;bottom:0;height:24svh;background:linear-gradient(to top,rgba(0,0,0,.95),rgba(0,0,0,0));pointer-events:none;z-index:5}
@@ -86,7 +86,8 @@ body.no-scroll main{overflow:hidden!important}
     position:relative;
     top:0;
     left:0;
-    transform:none;
+    transform-origin:top center;
+    transform:scale(1.3);
     width:100vw;
     max-width:100%;
     aspect-ratio:16/9;


### PR DESCRIPTION
## Summary
- anchor the desktop hero iframe to the top and scale it for a tighter crop without losing coverage
- mirror the top-anchored scaling within the mobile breakpoint to keep the punch-in consistent

## Testing
- Manual QA (Playwright screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68dfda4f2290832498553239a1b48ec3