### PR TITLE
Increase hero section height for larger video window

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 
 /* ---------------- Hero video ---------------- */
 .video-background-container{position:absolute;inset:0;overflow:hidden;z-index:0}
-.video-background-container iframe{position:absolute;top:50%;left:50%;min-width:100vw;min-height:100vh;transform:translate(-50%,-50%);pointer-events:none}
+.video-background-container iframe{position:absolute;top:0;left:50%;min-width:100vw;min-height:100vh;transform-origin:top center;transform:translateX(-50%) scale(1.3);pointer-events:none}
 @media (min-aspect-ratio:16/9){.video-background-container iframe{height:56.25vw;min-height:100vh}}
 @media (max-aspect-ratio:16/9){.video-background-container iframe{width:177.78vh;min-width:100vw}}
 .hero::after{content:"";position:absolute;inset-inline:0;bottom:0;height:24svh;background:linear-gradient(to top,rgba(0,0,0,.95),rgba(0,0,0,0));pointer-events:none;z-index:5}
@@ -86,7 +86,8 @@ body.no-scroll main{overflow:hidden!important}
     position:relative;
     top:0;
     left:0;
-    transform:none;
+    transform-origin:top center;
+    transform:scale(1.3);
     width:100vw;
     max-width:100%;
     aspect-ratio:16/9;
@@ -98,7 +99,7 @@ body.no-scroll main{overflow:hidden!important}
 
   /* 1) Hero layout: lower the text, small inline CTAs, leave a gap */
   .hero{
-    min-height:64svh;         /* ensures room for overlayed content */
+    min-height:96svh;         /* ensures room for overlayed content */
     background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
     padding-top:calc(env(safe-area-inset-top,0px) + 24px);
     padding-bottom:calc(var(--m-hero-gap) * 2);
@@ -190,7 +191,7 @@ body.no-scroll main{overflow:hidden!important}
 <main class="h-[100svh] overflow-y-auto md:h-auto md:overflow-visible pt-16 md:pt-20">
   <h1 class="sr-only">SanchezNinjah portfolio</h1>
     <!-- Hero Section -->
-    <section class="hero relative min-h-[70svh] md:min-h-[100svh] flex items-end pb-4 md:pb-24 pt-0 md:pt-0 text-white">
+    <section class="hero relative min-h-[90svh] md:min-h-[125svh] flex items-end pb-4 md:pb-24 pt-0 md:pt-0 text-white">
       <div class="video-background-container">
         <iframe id="heroVideo" src="https://www.youtube-nocookie.com/embed/VBdaOkpLe_o?autoplay=1&mute=1&loop=1&playlist=VBdaOkpLe_o&controls=0&modestbranding=1&enablejsapi=1" title="Background trailer" playsinline referrerpolicy="strict-origin-when-cross-origin" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
       </div>


### PR DESCRIPTION
## Summary
- raise the hero section minimum height on mobile to let the video occupy more of the viewport
- expand the desktop hero minimum height so the iframe window stretches further down the page

## Testing
- Manual QA (Playwright screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68dfda4f2290832498553239a1b48ec3