### PR TITLE
Restore mobile hero video overlay behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,48 +74,49 @@ body.no-scroll main{overflow:hidden!important}
 
   /* mobile-hero-iframe */
   .video-background-container{
-    position:relative;
-    inset:auto;
-    width:100vw;
-    max-width:100%;
-    margin-inline:auto;
+    position:absolute;
+    inset:0;
+    height:100%;
+    width:100%;
+    margin:0;
     overflow:hidden;
     flex-shrink:0;
   }
   .video-background-container iframe{
-    position:relative;
-    top:0;
-    left:0;
+    position:absolute;
+    inset:0;
     transform-origin:top center;
     transform:scale(1.3);
-    width:100vw;
-    max-width:100%;
-    aspect-ratio:16/9;
-    height:auto;
-    min-width:0;
-    min-height:0;
+    width:100%;
+    height:100%;
+    min-width:100%;
+    min-height:100%;
     object-fit:cover;
   }
 
   /* 1) Hero layout: lower the text, small inline CTAs, leave a gap */
   .hero{
+    position:relative;
     min-height:96svh;         /* ensures room for overlayed content */
     background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
     padding-top:calc(env(safe-area-inset-top,0px) + 24px);
-    padding-bottom:calc(var(--m-hero-gap) * 2);
+    padding-bottom:calc(var(--m-hero-gap) * 2.25);
+    padding-inline:1.5rem;
     transition:transform 220ms cubic-bezier(.2,.8,.2,1);
     display:flex;
     flex-direction:column;
-    justify-content:flex-start;
-    align-items:stretch;
+    justify-content:flex-end;
+    align-items:flex-start;
     gap:calc(var(--m-hero-gap) * 1.1);
   }
 
   /* mobile-hero-content-anchor */
   /* Flex stack the content below the video */
   .hero .hero-content{
+    position:relative;
     width:100%;
-    padding-inline:1.5rem;
+    padding:0;
+    margin-top:auto;
     display:flex;
     flex-direction:column;
     align-items:flex-start;


### PR DESCRIPTION
## Summary
- allow the mobile hero video container to fill the viewport again and drop the constraining aspect ratio sizing
- adjust mobile hero layout so the content stays layered over the video with bottom-aligned spacing

## Testing
- Manual - Viewed index.html at 375x812 using Playwright screenshot


------
https://chatgpt.com/codex/tasks/task_e_68dfe091a3ec832492769c9435bc0735