### PR TITLE
Fix mobile hero video centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,13 +84,14 @@ body.no-scroll main{overflow:hidden!important}
   }
   .video-background-container iframe{
     position:absolute;
-    inset:0;
+    top:0;
+    left:50%;
     transform-origin:top center;
-    transform:scale(1.3);
-    width:100%;
-    height:100%;
-    min-width:100%;
-    min-height:100%;
+    transform:translateX(-50%);
+    width:var(--m-hero-vid-w);
+    height:var(--m-hero-vid-h);
+    min-width:0;
+    min-height:0;
     object-fit:cover;
   }
 


### PR DESCRIPTION
## Summary
- align the mobile hero iframe positioning with the desktop centering logic
- size the mobile video using the custom CSS variables and clear minimum constraints so it remains centered

## Testing
- Manual test iPhone 8 viewport
- Manual test Android tall viewport

------
https://chatgpt.com/codex/tasks/task_e_68e0105abb508324a61915d3ae03b1d3