### PR TITLE
Fix mobile hero offset under fixed navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,11 +65,21 @@ body.no-scroll main{overflow:hidden!important}
 @media (max-width:768px){
   /* mobile-hero-anchors-vars */
   :root{
+    --m-nav-h:56px;            /* mobile nav height baseline */
     --m-hero-vid-w:130vw;          /* punch-in width (~30% total) */
     --m-hero-vid-h:73.125vw;       /* 16:9 of 130vw */
     --m-hero-gap:24px;             /* base vertical spacing unit */
     --m-hero-line:1.5rem;          /* synopsis line-height (≈24px) */
     --m-hero-tagline-line:1.2;     /* compact tagline leading */
+  }
+
+  /* mobile-fixed-nav-lock */
+  nav{
+    height:var(--m-nav-h);
+    display:flex;
+    align-items:center;
+    padding-top:0!important;
+    padding-bottom:0!important;
   }
 
   /* mobile-hero-iframe */
@@ -100,7 +110,7 @@ body.no-scroll main{overflow:hidden!important}
     position:relative;
     min-height:96svh;         /* ensures room for overlayed content */
     background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
-    padding-top:0;
+    padding-top:calc(env(safe-area-inset-top,0px) + var(--m-nav-h))!important;
     padding-bottom:calc(var(--m-hero-gap) * 2.25);
     padding-inline:1.5rem;
     transition:transform 220ms cubic-bezier(.2,.8,.2,1);
@@ -165,6 +175,7 @@ body.no-scroll main{overflow:hidden!important}
 
   /* 3) Section snap for “vertical cards sliding” feel */
   main{scroll-snap-type:y mandatory;overscroll-behavior-y:contain;scroll-padding-top:calc(env(safe-area-inset-top,0px) + 80px);-webkit-overflow-scrolling:touch;scroll-behavior:smooth}
+  main{margin-top:0!important;}
   main>section,.content-shelf{scroll-snap-align:start;scroll-snap-stop:normal}
 
   /* 4) Shelves are tighter; headings subtle */
@@ -175,7 +186,7 @@ body.no-scroll main{overflow:hidden!important}
 
   /* mobile-rowA-peek */
   /* 5) Minimize peek on short phones and add breathing room */
-  .content-shelf:first-of-type{margin-top:0;padding-top:calc(var(--m-hero-gap) * 1.2)}
+  .content-shelf:first-of-type{margin-top:0!important;padding-top:calc(var(--m-hero-gap) * 1.2)}
   .content-shelf:first-of-type>h3{
     opacity:1;pointer-events:auto;
     margin-top:calc(var(--m-hero-gap) * .3) !important;


### PR DESCRIPTION
## Summary
- add a mobile nav height CSS variable and reuse it to lock the fixed bar height
- offset the hero padding by the nav height plus safe-area inset to remove the mobile gap
- reset mobile top margins on main and the first content shelf to keep content aligned under the nav

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01c2f73f88324b01e624e0c909adb