### PR TITLE
Adjust mobile hero overlay positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,11 +114,12 @@ body.no-scroll main{overflow:hidden!important}
   /* mobile-hero-content-anchor */
   /* Flex stack the content below the video */
   .hero .hero-content{
-    position:relative;
+    position:absolute;
+    inset-inline:0;
+    top:calc(var(--m-hero-bottom-vh) - 0.9em);
     width:100%;
     padding:0;
     padding-top:calc(env(safe-area-inset-top,0px) + 24px);
-    margin-top:auto;
     display:flex;
     flex-direction:column;
     align-items:flex-start;


### PR DESCRIPTION
## Summary
- anchor the mobile hero text content with absolute positioning to align with the video bottom edge
- remove margin-based anchoring so the inset controls placement cleanly

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e028d92b908324a82dd26e6c0b5016