### PR TITLE
Update mobile shelf heading spacing to use gap variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@ body.no-scroll main{overflow:hidden!important}
   .content-shelf:first-of-type{margin-top:0;padding-top:calc(var(--m-hero-gap) * 1.2)}
   .content-shelf:first-of-type>h3{
     opacity:1;pointer-events:auto;
-    margin-top:calc(var(--m-hero-gap) * .3) !important;
+    margin-top:var(--m-gap-ctas-to-row) !important;
   }
   .content-shelf.shelf-active:first-of-type>h3{opacity:1;pointer-events:auto}
 }


### PR DESCRIPTION
## Summary
- update the mobile content shelf heading margin to use the shared `--m-gap-ctas-to-row` variable for consistent spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0296c0ec483249d8bf60db8b91bdb