### PR TITLE
Adjust mobile hero spacing overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,19 @@ body.no-scroll main{overflow:hidden!important}
     --m-gap-copy-cta:20px;
   }
 
+  .hero .hero-content>.mb-3{
+    margin-bottom:.75rem!important;
+  }
+  .hero .hero-content p.text-xs{
+    margin-bottom:.5rem!important;
+  }
+  .hero .hero-content p.text-sm{
+    margin-bottom:1.5rem!important;
+  }
+  .hero .grid{
+    gap:.75rem!important;
+  }
+
   /* mobile-hero-iframe */
   .video-background-container{
     position:absolute;


### PR DESCRIPTION
## Summary
- add mobile-specific margin overrides for hero heading, tagline, synopsis, and button grid
- ensure the mobile hero maintains intentional spacing despite the universal margin reset

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0322caf588324a6c7bb815e4c317f