### PR TITLE
Adjust mobile hero grid spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ body.no-scroll main{overflow:hidden!important}
     margin-bottom:1.5rem!important;
   }
   .hero .grid{
-    gap:.75rem!important;
+    gap:.6rem!important;
   }
 
   /* mobile-hero-iframe */
@@ -162,7 +162,7 @@ body.no-scroll main{overflow:hidden!important}
   }
 
   /* Put buttons on one line, make them smaller */
-  .hero .grid{gap:.75rem;grid-template-columns:repeat(2,minmax(0,1fr));margin-top:calc(var(--m-hero-gap) * .5);width:100%}
+  .hero .grid{gap:.6rem;grid-template-columns:repeat(2,minmax(0,1fr));margin-top:calc(var(--m-hero-gap) * .5);width:100%}
   .hero .grid button{padding:.45rem .7rem;min-height:38px;border-radius:9999px}
   .hero .grid button svg{width:18px;height:18px}
   .hero .grid button .text-lg{font-size:.9rem;line-height:1.2rem}


### PR DESCRIPTION
## Summary
- reduce the mobile hero grid gap to .6rem while keeping the existing layout settings intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e033e3a58c83248d5d519920c0ed7e