### PR TITLE
Adjust mobile content shelf spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@ body.no-scroll main{overflow:hidden!important}
 
   /* mobile-rowA-peek */
   /* 5) Minimize peek on short phones and add breathing room */
-  .content-shelf:first-of-type{margin-top:0;padding-top:calc(var(--m-hero-gap) * 1.2)}
+  .content-shelf:first-of-type{margin-top:0}
   .content-shelf:first-of-type>h3{
     opacity:1;pointer-events:auto;
     margin-top:var(--m-gap-ctas-to-row) !important;


### PR DESCRIPTION
## Summary
- remove the extra padding-top applied to the first content shelf in the mobile media query so the CTA margin controls the spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04710760c8324875acbe217c84188