### PR TITLE
Disable mobile scroll snapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,9 +182,9 @@ body.no-scroll main{overflow:hidden!important}
   .card-track>*+*{margin-left:0}
   .shelf-row{padding-block:.5rem;padding-inline:12px !important;}
 
-  /* 3) Section snap for “vertical cards sliding” feel */
-  main{scroll-snap-type:y mandatory;overscroll-behavior-y:contain;scroll-padding-top:calc(env(safe-area-inset-top,0px) + 80px);-webkit-overflow-scrolling:touch;scroll-behavior:smooth}
-  main>section,.content-shelf{scroll-snap-align:start;scroll-snap-stop:normal}
+  /* 3) Disable section snap on mobile */
+  main{scroll-snap-type:none !important;}
+  main>section,.content-shelf{scroll-snap-align:auto !important;scroll-snap-stop:normal !important;}
 
   nav{
     height:var(--m-nav-h);


### PR DESCRIPTION
## Summary
- disable main scroll snapping within the mobile media query
- update shelf section snap alignment to auto on mobile to neutralize snapping behavior

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e04d2284cc83248aee58d331fd179c