### PR TITLE
Guard shelf animations from coarse pointers

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,7 +705,7 @@ setTimeout(()=>{ suppressHover = false; }, 150);
 }
 
       // Mobile dock magnification effect
-if (isCoarse) {
+if (!isCoarse) {
   const cards = Array.from(track.querySelectorAll('.dock-card'));
   const updateDock = () => {
     // Only magnify when this shelf is active; otherwise keep baseline
@@ -761,7 +761,7 @@ shelf.addEventListener('scroll',      () => { if (previewOpen) hidePreviewImmedi
 }
       
 // Auto-center nearest card after scroll settles (mobile)
-if (isCoarse) {
+if (!isCoarse) {
   let alignTimer = null;
 
   const centerNearest = () => {


### PR DESCRIPTION
## Summary
- skip the dock magnification behavior when a coarse pointer is detected
- bypass the auto-centering helper on coarse pointers to avoid unwanted scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04dda08ec8324afca5b36b9d4f322