### PR TITLE
Allow JS to reposition mobile hero content

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,8 @@ body.no-scroll main{overflow:hidden!important}
   .hero .hero-content{
     position:absolute;
     inset-inline:0;
-    top:0 !important;
+    top:0;
+    will-change: top;
     width:100%;
     padding:0;
     padding-top:calc(env(safe-area-inset-top,0px) + 24px);


### PR DESCRIPTION
## Summary
- remove the !important flag from the mobile hero content top rule so inline styles can adjust it
- add a will-change hint for the top property to smooth future adjustments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05f3f25c48324ac12af119bd22f48