### PR TITLE
Remove legacy hero iframe aspect ratio media queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,6 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 /* ---------------- Hero video ---------------- */
 .video-background-container{position:absolute;inset:0;overflow:hidden;z-index:0}
 .video-background-container iframe{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none}
-@media (min-aspect-ratio:16/9){.video-background-container iframe{height:56.25vw;min-height:100vh}}
-@media (max-aspect-ratio:16/9){.video-background-container iframe{width:177.78vh;min-width:100vw}}
 .hero::after{content:"";position:absolute;inset-inline:0;bottom:0;height:24svh;background:linear-gradient(to top,rgba(0,0,0,.95),rgba(0,0,0,0));pointer-events:none;z-index:5}
 
 /* ---------------- Preview ---------------- */


### PR DESCRIPTION
## Summary
- remove the legacy aspect-ratio-based media queries on the hero iframe so it always uses the new sizing rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0684b90948324b445172dc8c4ac45