### PR TITLE
Remove redundant hero iframe media overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 
 /* ---------------- Hero video ---------------- */
 .video-background-container{position:absolute;inset:0;overflow:hidden;z-index:0}
-.video-background-container iframe{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;pointer-events:none}
+.video-background-container iframe{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;pointer-events:none}
 .hero::after{content:"";position:absolute;inset-inline:0;bottom:0;height:24svh;background:linear-gradient(to top,rgba(0,0,0,.95),rgba(0,0,0,0));pointer-events:none;z-index:5}
 
 /* ---------------- Preview ---------------- */
@@ -103,12 +103,6 @@ body.no-scroll main{overflow:hidden!important}
     overflow:hidden;
     flex-shrink:0;
   }
-  .video-background-container iframe{
-    position:absolute;
-    top:0;
-    left:0;
-  }
-
   /* 1) Hero layout: lower the text, small inline CTAs, leave a gap */
   .hero{
     position:relative;


### PR DESCRIPTION
## Summary
- remove redundant overrides on the hero video iframe so the base cover sizing is used everywhere

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e06a866fa48324b89d1fda890b3a17