### PR TITLE
Adjust mobile hero video and content offsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,11 +94,10 @@ body.no-scroll main{overflow:hidden!important}
   /* mobile-hero-iframe */
   .video-background-container{
     position:fixed;
-    top:calc(var(--m-nav-h) + env(safe-area-inset-top, 0px));
+    top:var(--m-nav-h);
     left:0;
-    right:0;
     width:100vw;
-    height:var(--m-hero-h);
+    height:var(--m-hero-h) !important;
     margin:0 !important;
     overflow:hidden;
     transform:none !important;
@@ -114,9 +113,8 @@ body.no-scroll main{overflow:hidden!important}
   /* 1) Hero layout: lower the text, small inline CTAs, leave a gap */
   .hero{
     position:relative;
-    min-height:var(--m-hero-h);         /* ensures room for overlayed content */
+    min-height:var(--m-hero-h) !important;         /* ensures room for overlayed content */
     background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
-    padding-top:env(safe-area-inset-top, 0px) !important;
     padding-bottom:calc(var(--m-hero-gap) * 2.25);
     padding-inline:1.5rem;
     transition:transform 220ms cubic-bezier(.2,.8,.2,1);
@@ -137,7 +135,6 @@ body.no-scroll main{overflow:hidden!important}
     will-change: top;
     width:100%;
     padding:0;
-    padding-top:calc(env(safe-area-inset-top,0px) + 24px);
     display:flex;
     flex-direction:column;
     align-items:flex-start;


### PR DESCRIPTION
## Summary
- set the fixed mobile hero video container to align with the nav height and enforce the hero height token
- keep the hero section at the mobile hero height without the safe-area padding
- remove the safe-area padding from the hero content so JS can control the offset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0711d60d88324ac2abd0c37da5307