### PR TITLE
Adjust hero layout classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,10 +221,10 @@ body.no-scroll main{overflow:hidden!important}
 /* moved: these mobile rules now live inside @media (max-width:768px) */
 </style>
 </head>
-<body class="overflow-x-hidden overflow-y-hidden h-[100svh] md:overflow-y-visible md:h-auto">
+<body class="overflow-x-hidden md:overflow-y-visible md:h-auto m-hero-reset">
   <!-- Fixed Navigation Bar -->
   <nav class="fixed top-0 left-0 right-0 bg-black border-b border-white/10 shadow-lg p-4 z-[100] flex items-center justify-between">   <div class="flex items-center space-x-8">     <a href="/" class="text-xl sm:text-2xl font-extrabold text-red-600 tracking-wide sm:tracking-wider whitespace-nowrap" aria-label="SanchezNinjah home">SanchezNinjah</a>     <ul class="hidden md:flex items-center space-x-6 text-sm font-medium text-gray-300">       <li><a href="/" class="text-white font-bold border-b-2 border-red-600 pb-1" aria-current="page">Home</a></li>       <li><a href="/shows" class="hover:text-white">TV Shows</a></li>       <li><a href="/movies" class="hover:text-white">Movies</a></li>       <li><a href="/list" class="hover:text-white">My List</a></li>     </ul>   </div>   <div class="flex items-center space-x-4">     <svg aria-hidden="true" focusable="false" class="w-6 h-6 text-gray-300 hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>     <svg aria-hidden="true" focusable="false" class="w-6 h-6 text-gray-300 hover:text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>   </div> </nav>
-<main class="h-[100svh] overflow-y-auto md:h-auto md:overflow-visible pt-0 md:pt-20">
+<main class="md:h-auto md:overflow-visible pt-0 md:pt-20">
   <h1 class="sr-only">SanchezNinjah portfolio</h1>
     <!-- Hero Section -->
     <section class="hero relative min-h-[90svh] md:min-h-[125svh] flex items-end text-white">


### PR DESCRIPTION
## Summary
- remove the mobile full-height and scroll locking utilities from the layout
- add the new `m-hero-reset` class to the body element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e073212b50832481d847dd4e25f677