### PR TITLE
Refine mobile hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
 <style>
 /* ---------------- Base ---------------- */
-:root{--hero-gap:1.5rem;--m-hero-h:78svh;--m-hero-gap:var(--hero-gap)}
+:root{--hero-gap:1.5rem;--m-hero-gap:var(--hero-gap);--m-hero-h:76svh}
 body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 .no-scrollbar::-webkit-scrollbar{display:none}.no-scrollbar{-ms-overflow-style:none;scrollbar-width:none}
 .content-card{position:relative;display:flex;align-items:stretch;justify-content:center;width:100%;height:100%;border-radius:.85rem;overflow:hidden;background:#111;box-shadow:0 18px 40px -12px rgba(0,0,0,.65);transition:transform .32s cubic-bezier(.25,.8,.25,1),box-shadow .32s ease;transform-origin:center;z-index:1}
@@ -34,7 +34,6 @@ body{background:#0d0d0d;font-family:'Inter',sans-serif;color:#f5f5f5}
 .title-chip{display:inline-flex;align-items:center;justify-content:center;padding:.5rem .875rem;background:rgba(17,17,17,.85);border-radius:.75rem;box-shadow:0 6px 20px rgba(0,0,0,.45),inset 0 0 0 2px rgba(229,9,20,.65)}
 .title-chip-text{font-weight:800;letter-spacing:.08em;color:#e50914;font-size:1.125rem}
 @media (min-width:768px){.title-chip-text{font-size:1.5rem}}
-@media (max-width:768px){.title-chip{padding:.4rem .75rem}.title-chip-text{font-size:1rem;letter-spacing:.09em}}
 .content-shelf{padding-block:.75rem;margin:0;content-visibility:auto;contain-intrinsic-size:600px}
 .hero+.row-section{margin-top:var(--hero-gap)!important}
 .hero .hero-content *{margin-bottom:0!important}
@@ -60,39 +59,44 @@ body.no-scroll main{overflow:hidden!important}
 .card-track>.relative{scroll-snap-align:start}
 @media (prefers-reduced-motion:reduce){.content-card,.hover-preview{transition:none!important}}
 .content-card:focus-visible{outline:3px solid #e50914;outline-offset:2px}
-
-/* ===================================================================
-   ==============  MOBILE — CLEAN CONSOLIDATED RULES  =================
-   =================================================================== */
 @media (max-width:768px){
-  /* mobile-hero-anchors-vars */
-  :root{
+  body.m-hero-reset{
     --m-hero-vid-w:192vw;
     --m-hero-vid-h:108vw;
     --m-hero-bottom-vh:46vh;
     --m-gap-ctas-to-row:28px;
-    --m-nav-h:64px;                /* fallback mobile nav height */
+    --m-nav-h:64px;
     --m-gap-chip-meta:12px;
     --m-gap-meta-copy:16px;
     --m-gap-copy-cta:20px;
     --m-synopsis-pad-bottom:6px;
+    overflow-x:hidden;
   }
 
-  .hero .hero-content>.mb-3{
-    margin-bottom:.75rem!important;
-  }
-  .hero .hero-content p.text-xs{
-    margin-bottom:.5rem!important;
-  }
-  .hero .hero-content p.text-sm{
-    margin-bottom:1.5rem!important;
-  }
-  .hero .grid{
-    gap:.75rem!important;
+  body.m-hero-reset .title-chip{padding:.4rem .75rem}
+
+  body.m-hero-reset .title-chip-text{font-size:1rem;letter-spacing:.09em}
+
+  body.m-hero-reset nav{
+    height:var(--m-nav-h);
+    display:flex;
+    align-items:center;
+    padding-block:0;
   }
 
-  /* mobile-hero-iframe */
-  .video-background-container{
+  body.m-hero-reset main{
+    margin-top:0 !important;
+    padding-top:0 !important;
+    scroll-snap-type:none !important;
+  }
+
+  body.m-hero-reset main>section,
+  body.m-hero-reset .content-shelf{
+    scroll-snap-align:auto !important;
+    scroll-snap-stop:normal !important;
+  }
+
+  body.m-hero-reset .video-background-container{
     position:fixed;
     top:var(--m-nav-h);
     left:0;
@@ -103,18 +107,24 @@ body.no-scroll main{overflow:hidden!important}
     transform:none !important;
     z-index:0;
   }
-  .video-background-container iframe{
+
+  body.m-hero-reset .video-background-container iframe{
     position:absolute;
-    inset:0;
-    width:100%;
-    height:100%;
+    top:50%;
+    left:50%;
+    width:calc(var(--m-hero-h) * 1.7778);
+    height:var(--m-hero-h);
+    transform:translate(-50%,-50%);
     border:0;
   }
-  /* 1) Hero layout: lower the text, small inline CTAs, leave a gap */
-  .hero{
+
+  body.m-hero-reset .hero{
     position:relative;
-    min-height:var(--m-hero-h) !important;         /* ensures room for overlayed content */
-    background-color:#0f0f10;background-image:none;background-size:cover;background-position:center;
+    min-height:var(--m-hero-h) !important;
+    background-color:#0f0f10;
+    background-image:none;
+    background-size:cover;
+    background-position:center;
     padding-bottom:calc(var(--m-hero-gap) * 2.25);
     padding-inline:1.5rem;
     transition:transform 220ms cubic-bezier(.2,.8,.2,1);
@@ -126,13 +136,15 @@ body.no-scroll main{overflow:hidden!important}
     margin-bottom:0 !important;
   }
 
-  /* mobile-hero-content-anchor */
-  /* Flex stack the content below the video */
-  .hero .hero-content{
+  body.m-hero-reset .hero.dimmed{
+    transform:translateY(-8px) scale(.94);
+  }
+
+  body.m-hero-reset .hero .hero-content{
     position:absolute;
     inset-inline:0;
     top:0;
-    will-change: top;
+    will-change:top;
     width:100%;
     padding:0;
     display:flex;
@@ -140,18 +152,28 @@ body.no-scroll main{overflow:hidden!important}
     align-items:flex-start;
     gap:var(--m-hero-gap);
   }
-  .hero .hero-content>*{
+
+  body.m-hero-reset .hero .hero-content>*{
     margin:0!important;
   }
-  .hero.dimmed{transform:translateY(-8px) scale(.94)}
-  .content-card:hover{transform:none!important;box-shadow:none!important;z-index:auto!important}
-  .content-card{transform-origin:top center;}
 
-  .hero-tagline{
+  body.m-hero-reset .hero .hero-content>.mb-3{
+    margin-bottom:.75rem!important;
+  }
+
+  body.m-hero-reset .hero .hero-content p.text-xs{
+    margin-bottom:.5rem!important;
+  }
+
+  body.m-hero-reset .hero .hero-content p.text-sm{
+    margin-bottom:1.5rem!important;
+  }
+
+  body.m-hero-reset .hero-tagline{
     line-height:var(--m-hero-tagline-line);
   }
 
-  .hero-synopsis{
+  body.m-hero-reset .hero-synopsis{
     display:-webkit-box;
     -webkit-box-orient:vertical;
     -webkit-line-clamp:4;
@@ -160,62 +182,108 @@ body.no-scroll main{overflow:hidden!important}
     overflow:hidden;
   }
 
-  /* Put buttons on one line, make them smaller */
-  .hero .grid{gap:.75rem;grid-template-columns:repeat(2,minmax(0,1fr));margin-top:calc(var(--m-hero-gap) * .5);width:100%}
-  .hero .grid button{padding:.45rem .7rem;min-height:38px;border-radius:9999px}
-  .hero .grid button svg{width:18px;height:18px}
-  .hero .grid button .text-lg{font-size:.9rem;line-height:1.2rem}
+  body.m-hero-reset .hero .grid{
+    gap:.75rem;
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    margin-top:calc(var(--m-hero-gap) * .5);
+    width:100%;
+  }
 
-  /* 2) Portrait posters — ~3 visible per viewport */
-  .dock-card{
-    width:clamp(6.25rem, 32vw, 8.5rem);
+  body.m-hero-reset .hero .grid button{
+    padding:.45rem .7rem;
+    min-height:38px;
+    border-radius:9999px;
+  }
+
+  body.m-hero-reset .hero .grid button svg{
+    width:18px;
+    height:18px;
+  }
+
+  body.m-hero-reset .hero .grid button .text-lg{
+    font-size:.9rem;
+    line-height:1.2rem;
+  }
+
+  body.m-hero-reset .content-card{
+    transform-origin:top center;
+  }
+
+  body.m-hero-reset .content-card:hover{
+    transform:none!important;
+    box-shadow:none!important;
+    z-index:auto!important;
+  }
+
+  body.m-hero-reset .dock-card{
+    width:clamp(6.25rem,32vw,8.5rem);
     aspect-ratio:2/3;
     height:auto;
     overflow:visible;
     transform-origin:center center;
     transition:transform 180ms cubic-bezier(.2,.8,.2,1),z-index 0s;
   }
-  .card-track{padding-inline:clamp(1rem, 5vw, 1.75rem);gap:clamp(.65rem,5vw,.85rem)}
-  .card-track>*+*{margin-left:0}
-  .shelf-row{padding-block:.5rem;padding-inline:12px !important;}
 
-  /* 3) Disable section snap on mobile */
-  main{scroll-snap-type:none !important;}
-  main>section,.content-shelf{scroll-snap-align:auto !important;scroll-snap-stop:normal !important;}
+  body.m-hero-reset .card-track{
+    padding-inline:clamp(1rem,5vw,1.75rem);
+    gap:clamp(.65rem,5vw,.85rem);
+  }
 
-  nav{
-    height:var(--m-nav-h);
+  body.m-hero-reset .card-track>*+*{
+    margin-left:0;
+  }
+
+  body.m-hero-reset .shelf-row{
+    padding-block:.5rem;
+    padding-inline:12px !important;
+  }
+
+  body.m-hero-reset .content-shelf{
+    padding-block:1rem;
+    padding-inline:clamp(1rem,5vw,1.75rem);
     display:flex;
-    align-items:center;
-    padding-block:0;
+    flex-direction:column;
+    gap:.75rem;
+    margin-top:0 !important;
+    padding-top:0 !important;
+    padding-inline:0 !important;
   }
 
-  main{
+  body.m-hero-reset .content-shelf>h3{
+    margin:0 !important;
+    color:#e5e7eb;
+    font-weight:700;
+    padding-inline:16px !important;
+  }
+
+  body.m-hero-reset .content-shelf>h3::after{
+    content:"";
+    display:block;
+    height:1px;
+    background:linear-gradient(to right,rgba(255,255,255,.18),rgba(255,255,255,.04));
+    margin-top:.25rem;
+  }
+
+  body.m-hero-reset .content-shelf.shelf-active>h3{
+    color:#fff;
+  }
+
+  body.m-hero-reset .content-shelf:first-of-type{
     margin-top:0 !important;
     padding-top:0 !important;
   }
 
-  .content-shelf:first-of-type{
-    margin-top:0 !important;
-    padding-top:0 !important;
-  }
-
-  /* 4) Shelves are tighter; headings subtle */
-  .content-shelf{padding-block:1rem;padding-inline:clamp(1rem,5vw,1.75rem);display:flex;flex-direction:column;gap:.75rem;margin-top:0 !important;padding-top:0 !important;padding-inline:0 !important;}
-  .content-shelf>h3{margin:0 !important;color:#e5e7eb;font-weight:700;padding-inline:16px !important;}
-  .content-shelf>h3::after{content:"";display:block;height:1px;background:linear-gradient(to right,rgba(255,255,255,.18),rgba(255,255,255,.04));margin-top:.25rem}
-  .content-shelf.shelf-active>h3{color:#fff}
-
-  /* mobile-rowA-peek */
-  /* 5) Minimize peek on short phones and add breathing room */
-  .content-shelf:first-of-type{margin-top:0 !important;padding-top:0 !important;}
-  .content-shelf:first-of-type>h3{
-    opacity:1;pointer-events:auto;
+  body.m-hero-reset .content-shelf:first-of-type>h3{
+    opacity:1;
+    pointer-events:auto;
     margin-top:var(--m-gap-ctas-to-row) !important;
   }
-  .content-shelf.shelf-active:first-of-type>h3{opacity:1;pointer-events:auto}
-}
 
+  body.m-hero-reset .content-shelf.shelf-active:first-of-type>h3{
+    opacity:1;
+    pointer-events:auto;
+  }
+}
 /* mobile-media-scope: removed duplicate mobile rules now inside @media (max-width:768px) */
 
 /* moved: these mobile rules now live inside @media (max-width:768px) */


### PR DESCRIPTION
## Summary
- align shared hero spacing variables and set the mobile hero height fallback to 76svh
- replace the mobile hero media query with body.m-hero-reset scoped rules that handle nav sizing, hero spacing, and fixed video backgrounds
- calculate the mobile iframe width from the hero height to simulate object-fit cover while keeping supporting preview and shelf styles intact

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e073fde45483248ed9932b76895619