### PR TITLE
Ensure hero CTA padding supports viewport units

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,9 +399,9 @@ body.no-scroll main{overflow:hidden!important}
     // ---------- Mobile helpers ----------
     const __vw = (value = '') => {
       const raw = String(value).trim();
-      if (!raw) return 0;
-      const num = parseFloat(raw);
-      if (Number.isNaN(num)) return 0;
+      if (!raw) return Number.NaN;
+      const num = Number.parseFloat(raw);
+      if (!Number.isFinite(num)) return Number.NaN;
       if (raw.endsWith('vw')) {
         const vw = window.visualViewport ? window.visualViewport.width : window.innerWidth;
         return (num / 100) * vw;
@@ -410,7 +410,7 @@ body.no-scroll main{overflow:hidden!important}
         const vh = window.visualViewport ? window.visualViewport.height : window.innerHeight;
         return (num / 100) * vh;
       }
-      return raw.endsWith('px') ? num : num;
+      return num;
     };
 
     const syncSynopsisToVideoBottom = () => {
@@ -424,7 +424,7 @@ body.no-scroll main{overflow:hidden!important}
       if (!hero || !content || !ctaGroup || !videoContainer) return;
 
       const styles = getComputedStyle(document.documentElement);
-      const ctaPadBottomRaw = styles.getPropertyValue('--m-cta-pad-bottom').trim() || '14px';
+      const ctaPadBottomRaw = styles.getPropertyValue('--m-cta-pad-bottom');
       let ctaPadBottom = __vw(ctaPadBottomRaw);
       if (!Number.isFinite(ctaPadBottom)) ctaPadBottom = 14;
 


### PR DESCRIPTION
## Summary
- restore the mobile hero `__vw` helper to convert px, vw, and vh values reliably
- read `--m-cta-pad-bottom` without coercing zero to a fallback and only default when the computed value is not finite

## Testing
- node - <<'NODE'
const window = {
  innerWidth: 360,
  innerHeight: 640,
  visualViewport: { width: 360, height: 640 }
};
const __vw = (value = '') => {
  const raw = String(value).trim();
  if (!raw) return Number.NaN;
  const num = Number.parseFloat(raw);
  if (!Number.isFinite(num)) return Number.NaN;
  if (raw.endsWith('vw')) {
    const vw = window.visualViewport ? window.visualViewport.width : window.innerWidth;
    return (num / 100) * vw;
  }
  if (raw.endsWith('vh')) {
    const vh = window.visualViewport ? window.visualViewport.height : window.innerHeight;
    return (num / 100) * vh;
  }
  return num;
};
['0', '0px', '0vw', '5vw', '10vh', '18px', '', '   '].forEach((value) => {
  const computed = __vw(value);
  const fallback = Number.isFinite(computed) ? computed : 14;
  console.log(value === '' ? '(empty)' : value, '=>', computed, '| fallback ->', fallback);
});
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e24e4619948324ab1ea3f7eab614b9