### PR TITLE
Wrap nav icons with accessible buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,32 +41,44 @@
         </ul>
       </div>
       <div class="flex items-center gap-4 text-gray-300">
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          class="h-6 w-6 transition hover:text-white"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
+        <button
+          type="button"
+          aria-label="Search"
+          class="flex h-6 w-6 items-center justify-center transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
         >
-          <circle cx="11" cy="11" r="8" />
-          <line x1="21" y1="21" x2="16.65" y2="16.65" />
-        </svg>
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          class="h-6 w-6 transition hover:text-white"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="h-full w-full"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          aria-label="Notifications"
+          class="flex h-6 w-6 items-center justify-center transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
         >
-          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
-          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-        </svg>
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="h-full w-full"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+          </svg>
+        </button>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- wrap the navigation search and notification icons in semantic buttons with descriptive aria-labels
- ensure the new controls retain sizing and hover treatments while providing a visible focus outline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e25cd7945c832486535f1b80e5b940