### PR TITLE
Fix hero gradient overlay bleed on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
 
 .hero-gradient{
   position:absolute;
-  left:0; right:0; bottom:0;
+  left:-1px; right:-1px; bottom:0;
   height:50%;
   background:linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,.85) 75%, #000 100%);
   pointer-events:none;


### PR DESCRIPTION
## Summary
- extend the hero gradient overlay 1px beyond each edge so it always covers the video overscan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2876fd4c083249418df4913ab93c9