### PR TITLE
Adjust hero offset to sit beneath sticky nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   p{ margin:8px 0; color:var(--muted); }
 
   /* HERO */
-  .video-hero{ position:relative; height:72vh; height:72svh; overflow:hidden; background:#000; }
+  .video-hero{ position:relative; height:72vh; height:72svh; overflow:hidden; background:#000; margin-top:-64px; padding-top:64px; }
   @media (max-height:700px){ .video-hero{ height:64vh; height:64svh; } }
   @media (min-height:900px){ .video-hero{ height:78vh; height:78svh; } }
 


### PR DESCRIPTION
## Summary
- offset the hero section upward by the navbar height
- add top padding so the hero retains its intended visual height beneath the nav

## Testing
- visual inspection of index.html in desktop and mobile viewports

------
https://chatgpt.com/codex/tasks/task_e_68e2ec8882b0832491499db976aab3ac