### PR TITLE
Handle mobile safe-area offset for hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,17 @@
   p{ margin:8px 0; color:var(--muted); }
 
   /* HERO */
-  .video-hero{ position:relative; height:72vh; height:72svh; overflow:hidden; background:#000; }
+  .video-hero{
+    position:relative;
+    height:72vh;
+    height:72svh;
+    overflow:hidden;
+    background:#000;
+    margin-top:-64px;
+    padding-top:64px;
+    margin-top:calc(-1 * (64px + env(safe-area-inset-top)));
+    padding-top:calc(64px + env(safe-area-inset-top));
+  }
   @media (max-height:700px){ .video-hero{ height:64vh; height:64svh; } }
   @media (min-height:900px){ .video-hero{ height:78vh; height:78svh; } }
 


### PR DESCRIPTION
## Summary
- keep the hero section flush to the sticky nav by including safe-area inset in its offset
- retain desktop behavior while eliminating the gap that appeared on mobile viewports with notches

## Testing
- Playwright screenshot (iPhone 12 viewport)


------
https://chatgpt.com/codex/tasks/task_e_68e2ec8882b0832491499db976aab3ac