### PR TITLE
Ensure hero video fills hero after safe-area offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,30 @@
   p{ margin:8px 0; color:var(--muted); }
 
   /* HERO */
-  .video-hero{ position:relative; height:72vh; height:72svh; overflow:hidden; background:#000; }
+  .video-hero{
+    position:relative;
+    height:72vh;
+    height:72svh;
+    overflow:hidden;
+    background:#000;
+    margin-top:-64px;
+    padding-top:64px;
+    margin-top:calc(-1 * (64px + env(safe-area-inset-top)));
+    padding-top:calc(64px + env(safe-area-inset-top));
+  }
   @media (max-height:700px){ .video-hero{ height:64vh; height:64svh; } }
   @media (min-height:900px){ .video-hero{ height:78vh; height:78svh; } }
 
-  .hero-video{ position:relative; width:100%; height:100%; overflow:hidden; background:#000; }
+  .hero-video{
+    position:relative;
+    width:100%;
+    height:calc(100% + 64px);
+    margin-top:-64px;
+    overflow:hidden;
+    background:#000;
+    height:calc(100% + 64px + env(safe-area-inset-top));
+    margin-top:calc(-1 * (64px + env(safe-area-inset-top)));
+  }
 
   .hero-text{ padding:64px 0; display:grid; gap:16px; }
   @media (max-width:600px){ .hero-text{ padding:48px 0; } }


### PR DESCRIPTION
## Summary
- extend the hero video wrapper upward so the iframe remains flush with the sticky nav despite the safe-area padding
- keep the additional height compensation for safe-area devices while ensuring the video fully covers the hero box

## Testing
- Playwright screenshot (iPhone 12 viewport)


------
https://chatgpt.com/codex/tasks/task_e_68e2ec8882b0832491499db976aab3ac