### PR TITLE
Align hero video with navigation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   p{ margin:8px 0; color:var(--muted); }
 
   /* HERO */
-  .video-hero{ position:relative; height:72vh; height:72svh; overflow:hidden; background:#000; margin-top:-64px; padding-top:64px; }
+  .video-hero{ position:relative; height:72vh; height:72svh; overflow:hidden; background:#000; }
   @media (max-height:700px){ .video-hero{ height:64vh; height:64svh; } }
   @media (min-height:900px){ .video-hero{ height:78vh; height:78svh; } }
 


### PR DESCRIPTION
## Summary
- remove the negative margin and padding used on the hero so the video sits directly beneath the navigation bar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ec3e3b808324af251115c86983ca