### PR TITLE
Allow hero autoplay then unmute

### DIFF
--- a/index.html
+++ b/index.html
@@ -3242,7 +3242,7 @@ body.debug-row-zones .row-nav-zone{
     ytPlayerInitialized = true;
     ytPlayer = new YT.Player('hero-yt', {
       playerVars: {
-        autoplay: 0,
+        autoplay: 1,
         mute: 1,
         playsinline: 1,
         controls: 0,
@@ -3256,8 +3256,8 @@ body.debug-row-zones .row-nav-zone{
           if (typeof e.target.setVolume === 'function') {
             e.target.setVolume(heroUiVolume);
           }
-          if (typeof e.target.mute === 'function') {
-            e.target.mute();
+          if (typeof e.target.playVideo === 'function') {
+            e.target.playVideo();
           }
           isMuted = true;
           updateHeroMuteUi();
@@ -3266,6 +3266,11 @@ body.debug-row-zones .row-nav-zone{
           if (e.data === YT.PlayerState.PLAYING) {
             hasUserGesturePlayback = true;
             window.heroPlaybackRequested = true;
+            if (typeof e.target.unMute === 'function') {
+              e.target.unMute();
+            }
+            isMuted = false;
+            updateHeroMuteUi();
             scheduleHeroPosterFadeNearEnd(e.target);
           }
           if (e.data === YT.PlayerState.ENDED) {
@@ -10252,8 +10257,5 @@ document.addEventListener('keydown', (event) => {
 </html>
 
 \n<!-- WRITE TEST -->
-
-
-
 
 


### PR DESCRIPTION
### Motivation
- Autoplay was being blocked in some browsers when the hero video attempted to start with audio enabled, so the hero should start muted to satisfy autoplay policies and then enable audio once playback actually begins.  
- The hero UI mute state must reflect the actual player state so the control and visuals remain consistent.

### Description
- Start the iframe source with `mute=1` and update the hero player `playerVars` to `autoplay:1` and `mute:1` so the video can autoplay muted.  
- Initialize `isMuted` to `true` and call `playVideo()` in the player's `onReady` handler to trigger playback.  
- In the player's `onStateChange` handler, unmute via `e.target.unMute()` when the player reports `YT.PlayerState.PLAYING`, set `isMuted = false`, and call `updateHeroMuteUi()` so the UI reflects the unmuted state.  
- Preserve existing poster fade scheduling and safety checks around player readiness.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989ceb6b1888324bf45e9b66afe241d)